### PR TITLE
Use font-size-small instead of hard-coding the font size for the transmission combo box in MainWindow's QToolbar.

### DIFF
--- a/OSX Dark.qss
+++ b/OSX Dark.qss
@@ -919,7 +919,7 @@ UserView::item {
 }
 
 #qtIconToolbar QComboBox {
-  font-size: 8pt;
+  font-size: 11pt;
 }
 
 .log-time {

--- a/OSX Lite.qss
+++ b/OSX Lite.qss
@@ -919,7 +919,7 @@ UserView::item {
 }
 
 #qtIconToolbar QComboBox {
-  font-size: 8pt;
+  font-size: 11pt;
 }
 
 .log-time {

--- a/source/Imports/Base Theme.scss
+++ b/source/Imports/Base Theme.scss
@@ -1056,7 +1056,7 @@ UserView::item
 
 #qtIconToolbar QComboBox
 {
-	font-size:8pt;
+	font-size: $font-size-small;
 }
 
 .log-time


### PR DESCRIPTION
On macOS, the size for this text is defined by $font-size-small
variable.

On other OSes, the size for small is 8pt, but for macOS it is 11pt.

Also, regenerate the .qss files.